### PR TITLE
Fix top-level multiline comment matching

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -58,7 +58,7 @@ export function activate(context: vscode.ExtensionContext) {
 	};
 
 	let findMultilineComments = function () {
-		const regEx = /(^|[ \t])(\/\*)+([\s\S]*?)(\*\/)/g;
+		const regEx = /(^|[ \t])(\/\*)+([\s\S]*?)(\*\/)/gm;
 		const text = activeEditor.document.getText();
 		const commentRegEx = /(^)+([ \t]*)?(\!|\?|\*|(todo(:)?))+( )*?([a-z])+([^*/\r\n]*)/igm;
 


### PR DESCRIPTION
Add the multiline flag to regEx in findMultilineComments() so that
the ^ anchor will match the beginning of a line, rather than only
the beginning of the string. This allows findMultilineComments()
to find top-level (non-indented) block comments which are not
on the first line of the active editor.
Behavior of the current release:  
![multiline-before](https://user-images.githubusercontent.com/7611356/28251756-2b939c72-6a52-11e7-8a22-3d5331097466.gif)  
  
Behavior of this commit:  
![multiline-after](https://user-images.githubusercontent.com/7611356/28251783-fe7ce30a-6a52-11e7-8a53-a81b4aa1163f.gif)

